### PR TITLE
[Documentation] Added androidx javadoc reference

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ _site/
 .sass-cache/
 .jekyll-cache/
 .jekyll-metadata
+/.idea/

--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ This page helps Android developers find the sources they're looking for.
 * View internals? See [View.java](https://cs.android.com/android/platform/superproject/+/master:frameworks/base/core/java/android/view/View.java).
 * Activity lifecycle? See [ActivityThread.java](https://cs.android.com/android/platform/superproject/+/master:frameworks/base/core/java/android/app/ActivityThread.java).
 * Art Runtime? See [class.cc](https://cs.android.com/android/platform/superproject/+/master:art/runtime/mirror/class.cc).
+* Androidx javadoc [androidx.de](https://androidx.de/index.html) 
 
 ## What if it's a new version, sources not available yet?
 


### PR DESCRIPTION
[androidx.dex](https://androidx.de/index.html) provides clear documentation that has details such as:
- it has the artifact for the Gradle dependencies. 
- it has an overview.
- it has source code.

and the best thing from the documentation is that everything in the same page. So no need to juggle around to check which version on maven for that particular androidx libraries.

in contrast to official androidx. it has a single page that collects all information for library versioning which you're able to check here [androidx version](https://developer.android.com/jetpack/androidx/versions).

